### PR TITLE
Readme inconsistency fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ payment.shipping = {
 #### Alternativamente você pode definir uma instância da classe `PagSeguro::Shipping`
 
 ```ruby
-shipping = {
+shipping_options = {
   type_name: "sedex",
   cost: 20.00,
   address: {
@@ -209,7 +209,7 @@ shipping = {
   }
 }
 
-payment.shipping = shipping
+payment.shipping = PagSeguro::Shipping.new(shipping_options)
 ```
 
 #### Definindo informações do comprador


### PR DESCRIPTION
[This example](https://github.com/pagseguro/ruby/blob/master/README.md#alternativamente-você-pode-definir-uma-instância-da-classe-pagseguroshipping) does not make any sense (it's mostly a repetition from the previous one), since the text above suggests you could explicitly instantiate `PagSeguro::Shipping` class.
