### PR TITLE
PaymentRequest com email e token alternativos

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ class CheckoutController < ApplicationController
     order = Order.find(params[:id])
 
     payment = PagSeguro::PaymentRequest.new
+
+    # Você também pode fazer o request de pagamento usando credenciais 
+    # diferentes, como no exemplo abaixo
+
+    payment = PagSeguro::PaymentRequest.new(email: 'abc@email', token: 'token')
+
     payment.reference = order.id
     payment.notification_url = notifications_url
     payment.redirect_url = processing_url

--- a/lib/pagseguro/payment_request.rb
+++ b/lib/pagseguro/payment_request.rb
@@ -51,6 +51,13 @@ module PagSeguro
     # complete the payment.
     attr_accessor :abandon_url
 
+    # The email that identifies the request. Defaults to PagSeguro.email
+    attr_accessor :email
+
+    # The token that identifies the request. Defaults to PagSeguro.token
+    attr_accessor :token
+
+
     # Products/items in this payment request.
     def items
       @items ||= Items.new
@@ -68,13 +75,18 @@ module PagSeguro
 
     # Calls the PagSeguro web service and register this request for payment.
     def register
-      params = Serializer.new(self).to_params
+      params = Serializer.new(self).to_params.merge({
+        email: email,
+        token: token
+      })
       Response.new Request.post("checkout", params)
     end
 
     private
     def before_initialize
       self.currency = "BRL"
+      self.email    = PagSeguro.email
+      self.token    = PagSeguro.token
     end
 
     def endpoint

--- a/lib/pagseguro/request.rb
+++ b/lib/pagseguro/request.rb
@@ -45,8 +45,8 @@ module PagSeguro
 
     def extended_data(data)
       data.merge(
-        email: PagSeguro.email,
-        token: PagSeguro.token,
+        email: data[:email] || PagSeguro.email,
+        token: data[:token] || PagSeguro.token,
         charset: PagSeguro.encoding
       )
     end

--- a/spec/pagseguro/payment_request_spec.rb
+++ b/spec/pagseguro/payment_request_spec.rb
@@ -9,6 +9,8 @@ describe PagSeguro::PaymentRequest do
   it_assigns_attribute :max_uses
   it_assigns_attribute :notification_url
   it_assigns_attribute :abandon_url
+  it_assigns_attribute :email
+  it_assigns_attribute :token
 
   it_ensures_type PagSeguro::Sender, :sender
   it_ensures_type PagSeguro::Shipping, :shipping
@@ -30,6 +32,30 @@ describe PagSeguro::PaymentRequest do
     expect(payment.currency).to eql("BRL")
   end
 
+  describe "#email" do
+    before { PagSeguro.email = 'DEFAULT_EMAIL' }
+
+    it "returns the email set in the contstructor" do
+      expect(described_class.new(email: 'foo').email).to eq('foo')
+    end
+
+    it "defaults to PagSeguro.email" do
+      expect(described_class.new.email).to eq('DEFAULT_EMAIL')
+    end
+  end
+
+  describe "#token" do
+    before { PagSeguro.token = 'DEFAULT_TOKEN' }
+
+    it "returns the token set in the contstructor" do
+      expect(described_class.new(token: 'foo').token).to eq('foo')
+    end
+
+    it "defaults to PagSeguro.token" do
+      expect(described_class.new.token).to eq('DEFAULT_TOKEN')
+    end
+  end
+
   describe "#register" do
     let(:payment) { PagSeguro::PaymentRequest.new }
     before { FakeWeb.register_uri :any, %r[.*?], body: "" }
@@ -45,6 +71,12 @@ describe PagSeguro::PaymentRequest do
 
     it "performs request" do
       params = double
+
+      params.should_receive(:merge).with({
+        email: PagSeguro.email,
+        token: PagSeguro.token
+      }).and_return(params)
+
       PagSeguro::PaymentRequest::Serializer.any_instance.stub to_params: params
 
       PagSeguro::Request

--- a/spec/pagseguro/request_spec.rb
+++ b/spec/pagseguro/request_spec.rb
@@ -21,6 +21,14 @@ describe PagSeguro::Request do
       expect(FakeWeb.last_request.body).to include("email=EMAIL&token=TOKEN")
     end
 
+    it "includes custom credentials" do
+      PagSeguro.email = "EMAIL"
+      PagSeguro.token = "TOKEN"
+      PagSeguro::Request.post("checkout", email: 'foo', token: 'bar')
+
+      expect(FakeWeb.last_request.body).to include("email=foo&token=bar")
+    end
+
     it "includes encoding" do
       PagSeguro::Request.post("checkout")
       expect(FakeWeb.last_request.body).to include("charset=UTF-8")


### PR DESCRIPTION
Este commit habilita fazer um request com credenciais diferentes da padrão:

``` ruby
payment = PagSeguro::PaymentRequest.new(email: 'abc@email', token: 'token')
```
