### PR TITLE
Adding sandbox's URL support

### DIFF
--- a/lib/pagseguro.rb
+++ b/lib/pagseguro.rb
@@ -46,8 +46,7 @@ module PagSeguro
     # The encoding that will be used.
     attr_accessor :encoding
 
-    # The PagSeguro environment.
-    # Only +production+ for now.
+    # The PagSeguro environment. Available options are :production and :sandbox.
     attr_accessor :environment
   end
 
@@ -60,6 +59,10 @@ module PagSeguro
       production: {
         api: "https://ws.pagseguro.uol.com.br/v2",
         site: "https://pagseguro.uol.com.br/v2"
+      },
+      sandbox: {
+        api: "https://ws.sandbox.pagseguro.uol.com.br/v2",
+        site: "https://sandbox.pagseguro.uol.com.br/v2"
       }
     }
   end

--- a/spec/pagseguro/pagseguro_spec.rb
+++ b/spec/pagseguro/pagseguro_spec.rb
@@ -33,8 +33,20 @@ describe PagSeguro do
       }.to raise_exception(PagSeguro::InvalidEnvironmentError)
     end
 
-    it "returns api url" do
-      expect(PagSeguro.api_url("/some/path")).to eql("https://ws.pagseguro.uol.com.br/v2/some/path")
+    context 'when environment is production' do
+      it "returns api url" do
+        expect(PagSeguro.api_url("/some/path")).to eql("https://ws.pagseguro.uol.com.br/v2/some/path")
+      end
+    end
+
+    context 'when environment is sandbox' do
+      before do
+        PagSeguro.environment = :sandbox
+      end
+
+      it "returns sandbox's api url" do
+        expect(PagSeguro.api_url("/some/path")).to eql("https://ws.sandbox.pagseguro.uol.com.br/v2/some/path")
+      end
     end
   end
 
@@ -47,8 +59,20 @@ describe PagSeguro do
       }.to raise_exception(PagSeguro::InvalidEnvironmentError)
     end
 
-    it "returns site url" do
-      expect(PagSeguro.site_url("/some/path")).to eql("https://pagseguro.uol.com.br/v2/some/path")
+    context 'when environment is production' do
+      it "returns site url" do
+        expect(PagSeguro.site_url("/some/path")).to eql("https://pagseguro.uol.com.br/v2/some/path")
+      end
+    end
+
+    context 'when environment is sandbox' do
+      before do
+        PagSeguro.environment = :sandbox
+      end
+
+      it "returns sandbox's site url" do
+        expect(PagSeguro.site_url("/some/path")).to eql("https://sandbox.pagseguro.uol.com.br/v2/some/path")
+      end
     end
   end
 end


### PR DESCRIPTION
Added sandbox URLs in order to facilitate the test of new apps using PagSeguro's gem
