### PR TITLE
fix: updated gems to keep compatibility with rails 6.1.4.1

### DIFF
--- a/lib/pagseguro/version.rb
+++ b/lib/pagseguro/version.rb
@@ -1,3 +1,3 @@
 module PagSeguro
-  VERSION = "2.6.1.1"
+  VERSION = "2.6.1"
 end


### PR DESCRIPTION
Updated some gems that were conflicting with the update to the latest version of Rails (6.1.4.1).

These changes have been in production since 09.02.2021, no bug reports by our system users so far.